### PR TITLE
Cache the APK and WASM builds

### DIFF
--- a/.github/workflows/apk_gallery.yaml
+++ b/.github/workflows/apk_gallery.yaml
@@ -22,6 +22,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
+            - name: Cache APK build
+              id: cache-apk
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      target/release/apk/slint_material.apk
+                  key: apk-build-${{ hashFiles('examples/gallery/**', 'ui/**') }}
             - name: Install Android API level 30
               run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "platforms;android-30"
             - name: Install Rust
@@ -48,6 +55,7 @@ jobs:
                   mkdir -p /home/runner/.android
                   echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > $CARGO_APK_RELEASE_KEYSTORE
             - name: Build
+              if: steps.cache-apk.outputs.cache-hit != 'true'
               working-directory: examples/gallery
               run: cargo apk build --target aarch64-linux-android --lib --release
             - name: "Upload Artifacts"

--- a/.github/workflows/wasm_gallery.yaml
+++ b/.github/workflows/wasm_gallery.yaml
@@ -15,6 +15,15 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
+            - name: Cache WASM build
+              id: cache-wasm
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      examples/gallery/pkg
+                      examples/gallery/index.html
+                      examples/gallery/frame-tablet.webp
+                  key: wasm-build-${{ hashFiles('examples/gallery/**', 'ui/**') }}
             - name: Install Rust
               uses: dtolnay/rust-toolchain@stable
               with:
@@ -25,6 +34,7 @@ jobs:
               with:
                   key: wasm-build
             - name: Build
+              if: steps.cache-wasm.outputs.cache-hit != 'true'
               working-directory: examples/gallery
               run: wasm-pack build --target web
             - name: "Upload Artifacts"


### PR DESCRIPTION
The APK and WASM gallery are rebuilt on any CI run. This caches the results and only rebuilds if the gallery and/or ui source files change.