### PR TITLE
If search has some text, the focus should go to the end of the typed query

### DIFF
--- a/ui/components/search_bar.slint
+++ b/ui/components/search_bar.slint
@@ -98,8 +98,13 @@ component SearchTextInput  {
             key_released(event) => {
                 root.key_released(event)
             }
-        }
 
+            init => {
+                if root.text.character_count > 0 {
+                    self.set_selection_offsets(root.text.character_count, root.text.character_count);
+                }
+            }
+        }
         if root.text == "" && root.placeholder != "" : MaterialText {
             width: 100%;
             height: 100%;


### PR DESCRIPTION
Previously when the focus went back to the search query the cursor was 
at the start of the query, not the end.