### PR TITLE
Add index-changed callback to Nav items

### DIFF
--- a/docs/src/content/docs/components/AppBars/navigation_bar.mdx
+++ b/docs/src/content/docs/components/AppBars/navigation_bar.mdx
@@ -50,7 +50,7 @@ An array of navigation items to display in the bar.
 ## Callbacks
 
 ### index-changed(index: int)
-Invoked when the currently selected navigation item changes.
+Invoked when the `current-index` changes.
 
 ## Functions
 

--- a/docs/src/content/docs/components/AppBars/tab_bar.mdx
+++ b/docs/src/content/docs/components/AppBars/tab_bar.mdx
@@ -39,3 +39,8 @@ The index of the currently selected tab.
 <SlintProperty propName="items" typeName="[struct]" structName="NavigationItem">
 An array of tab items to display in the bar.
 </SlintProperty>
+
+## Callbacks
+
+### index-changed(index: int)
+Invoked when the `current-index` changes.

--- a/docs/src/content/docs/components/Navigation/navigation_rail.mdx
+++ b/docs/src/content/docs/components/Navigation/navigation_rail.mdx
@@ -57,6 +57,9 @@ An array of navigation items to display in the rail.
 
 ## Callbacks
 
+### index-changed(index: int)
+Invoked when the `current-index` changes.
+
 ### menu-clicked()
 Invoked when the menu button is clicked.
 

--- a/ui/components/base_navigation.slint
+++ b/ui/components/base_navigation.slint
@@ -13,7 +13,6 @@ export component BaseNavigationItemTemplate {
     in property <string> badge;
 
     callback clicked;
-    callback index_changed(index: int);
     callback pointer_event(event: PointerEvent, position: Point);
 
     accessible-role: tab;
@@ -25,14 +24,13 @@ export component BaseNavigationItemTemplate {
 
     @children
 
-    changed index => {
-        root.index_changed(root.index);
-    }
 }
 
 export component BaseNavigation {
     in property <[NavigationItem]> items;
     in_out property <int> current_index;
+
+    callback index_changed(index: int);
 
     accessible-role: tab-list;
     // accessible-delegate-focus: root.current-focused >= 0 ? root.current-focused : root.current-index;
@@ -47,5 +45,7 @@ export component BaseNavigation {
         }
 
         root.current_index = index;
+        root.index_changed(index);
     }
+
 }


### PR DESCRIPTION
NaviagtionBar, NavigationRail and TabBar all gain an explicit 
`index-changed(index)` callback.